### PR TITLE
resolved the issue #1 of crashes when debugging

### DIFF
--- a/src/libsrc/XPlaneBeaconListener.cpp
+++ b/src/libsrc/XPlaneBeaconListener.cpp
@@ -149,7 +149,9 @@ void XPlaneBeaconListener::runListener() {
 
 		if (recv_len < 0) {
 
-			if (errno != EWOULDBLOCK) {
+			if(errno == EINTR)
+				continue;	//see http://250bpm.com/blog:12
+			if (errno != EWOULDBLOCK && errno != EAGAIN) {
 				ostringstream buf;
 				buf << "recvfrom returned " << recv_len << " errno is " << errno
 						<< endl;

--- a/src/libsrc/XPlaneUDPClient.cpp
+++ b/src/libsrc/XPlaneUDPClient.cpp
@@ -206,7 +206,9 @@ void XPlaneUDPClient::listenerThread() {
 		if ((recv_len = recvfrom(sock, buf, sizeof(buf), 0,
 				(struct sockaddr *) &remoteAddr, &slen)) < 0) {
 
-			if (errno != EWOULDBLOCK) {
+			if(errno == EINTR)
+				continue;	//see http://250bpm.com/blog:12
+			if (errno != EWOULDBLOCK && errno != EAGAIN) {
 				ostringstream buf;
 				buf << "recvfrom returned " << recv_len << " errno is " << errno
 						<< endl;


### PR DESCRIPTION
The issue with crashes when debugging is resolved.

I added a handler for EINTR errors when receiving from the socket. Such interruptions occur when debugging the code using gdb.
Now these EINTR-errors are silently swallowed and another retry to receive from the socket is issued.
See:
[https://www.gnu.org/software/libc/manual/html_node/Interrupted-Primitives.html#Interrupted-Primitives](https://www.gnu.org/software/libc/manual/html_node/Interrupted-Primitives.html#Interrupted-Primitives)
and
[http://250bpm.com/blog:12](http://250bpm.com/blog:12)
This resolves #1 